### PR TITLE
dequote to avoid error

### DIFF
--- a/hivedump
+++ b/hivedump
@@ -192,6 +192,8 @@ sub dump_db {
 	map {
 		if (/CREATE(\s+EXTERNAL)?\s+TABLE\s+([^\(\s]+).*PARTITIONED\s+BY/) {
 			my $table = $2;
+                        # the table name is like `foo`, dequote it to avoid error.
+                        $table =~ s/`(.*)`/$1/;
 			print STDERR "  . scanning partitions on table $table\n";
 
 			my @partitions = split "\n", qx|$hive cli -e "use $db; show partitions $table;" 2>/dev/null|;


### PR DESCRIPTION
The parsed table name is like \`foo\`, the quotes will cause error.