### PR TITLE
several fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 Simple tool to dump hive tables metadata. It requires **Perl** and **Getopts::Long** module only.
 
     $ ./hivedump -h
-    
+
     Usage: ./hivedump [options] > dump.hql
-   
+
       --database=<db_name>  Specify the DB to export
       --all-databases       Export all databases
       --if-not-exists       Add "IF NOT EXISTS" after "CREATE TABLE"

--- a/hivedump
+++ b/hivedump
@@ -129,7 +129,7 @@ sub get_ddl {
 	#
 	# Add DROP TABLE/VIEW before CREATE TABLE/VIEW, if $drop_table is true
 	#
-	$ddl =~ s/CREATE(\s+EXTERNAL)?\s+(TABLE|VIEW)\s+([^\n(\s]+)/DROP $2 $3;\n\nCREATE $2 $3/g if $drop_table;
+	$ddl =~ s/CREATE(\s+EXTERNAL)?\s+(TABLE|VIEW)\s+([^\n(\s]+)/DROP $2 IF EXISTS $3;\n\nCREATE $2 $3/g if $drop_table;
 
 	#
 	# Add IF NOT EXISTS after CREATE TABLE/VIEW if $if_not_exists is true
@@ -149,7 +149,7 @@ sub get_ddl {
 	#
 	# Escape column names to avoid clashes with reserved words
 	#
-	$ddl = escape_columns($ddl);
+        #$ddl = escape_columns($ddl);
 
 	return ($ddl);
 }

--- a/hivedump
+++ b/hivedump
@@ -129,7 +129,7 @@ sub get_ddl {
 	#
 	# Add DROP TABLE/VIEW before CREATE TABLE/VIEW, if $drop_table is true
 	#
-	$ddl =~ s/CREATE(\s+EXTERNAL)?\s+(TABLE|VIEW)\s+([^\n(\s]+)/DROP $2 IF EXISTS $3;\n\nCREATE $2 $3/g if $drop_table;
+	$ddl =~ s/CREATE(\s+EXTERNAL)?\s+(TABLE|VIEW)\s+([^\n(\s]+)/DROP $2 IF EXISTS $3;\n\nCREATE $1 $2 $3/g if $drop_table;
 
 	#
 	# Add IF NOT EXISTS after CREATE TABLE/VIEW if $if_not_exists is true

--- a/hivedump
+++ b/hivedump
@@ -129,7 +129,7 @@ sub get_ddl {
 	#
 	# Add DROP TABLE/VIEW before CREATE TABLE/VIEW, if $drop_table is true
 	#
-	$ddl =~ s/CREATE(\s+EXTERNAL)?\s+(TABLE|VIEW)\s+([^\n(\s]+)/DROP $2 IF EXISTS $3;\n\nCREATE $1 $2 $3/g if $drop_table;
+	$ddl =~ s/CREATE(\s+EXTERNAL)?\s+(TABLE|VIEW)\s+([^\n(\s]+)/DROP $2 IF EXISTS $3;\n\nCREATE$1 $2 $3/g if $drop_table;
 
 	#
 	# Add IF NOT EXISTS after CREATE TABLE/VIEW if $if_not_exists is true

--- a/hivedump
+++ b/hivedump
@@ -211,7 +211,7 @@ sub dump_db {
 	#
 	# Prints the DDL with a 'use <DB_name>;' statement on top
 	#
-	print "use $db;\n\n$ddl\n";
+	print "CREATE DATABASE IF NOT EXISTS $db;\n\nUSE $db;\n\n$ddl\n";
 	print STDERR "  . dump done\n";
 }
 

--- a/hivedump
+++ b/hivedump
@@ -149,7 +149,7 @@ sub get_ddl {
 	#
 	# Escape column names to avoid clashes with reserved words
 	#
-        $ddl = escape_columns($ddl);
+	$ddl = escape_columns($ddl);
 
 	return ($ddl);
 }

--- a/hivedump
+++ b/hivedump
@@ -149,7 +149,7 @@ sub get_ddl {
 	#
 	# Escape column names to avoid clashes with reserved words
 	#
-        #$ddl = escape_columns($ddl);
+        $ddl = escape_columns($ddl);
 
 	return ($ddl);
 }
@@ -256,7 +256,7 @@ sub escape_columns {
 		if ($line =~ m/(CREATE(\s+EXTERNAL)?\s+TABLE|PARTITIONED\s+BY)/ and defined $ddl[0]) {
 			while ($ddl[0] =~ /^\s/) {
 				my $subline = shift @ddl;
-				$subline =~ s/^(\s+)([^\s]+)/$1`$2`/;
+                                $subline =~ s/^(\s+)([^\s]+)/$1`$2`/ unless $subline =~ m/^\s+`/;
 				push @out, $subline;
 				last unless defined $ddl[0];
 			}

--- a/hivedump
+++ b/hivedump
@@ -61,15 +61,13 @@ sub main {
 	if (length($db)) {
 		dump_db($db);
 	} elsif ($all_db) {
-		for my $db_name (get_databases()) {
-			dump_db($db_name);
-		}
+                dump_databases();
 	} else {
 		usage("Provide exactly one of --all-databases or --database=<db_name>");
 	}
 }
 
-sub get_databases {
+sub dump_databases {
 	my @db_list = qx|$hive cli -e "show databases" 2>/dev/null|;
 	map chomp, @db_list;
 
@@ -235,7 +233,7 @@ sub suppress {
 		if ($line =~ m/$pattern/) {
 			while ($ddl[0] =~ /^\s/) { shift @ddl; }
 		} else {
-			push @out, $line;	
+			push @out, $line;
 		}
 	}
 
@@ -253,13 +251,13 @@ sub escape_columns {
 	while (1) {
 		my $line = shift(@ddl);
 		last unless defined $line;
-		push @out, $line;	
+		push @out, $line;
 
 		if ($line =~ m/(CREATE(\s+EXTERNAL)?\s+TABLE|PARTITIONED\s+BY)/ and defined $ddl[0]) {
 			while ($ddl[0] =~ /^\s/) {
 				my $subline = shift @ddl;
 				$subline =~ s/^(\s+)([^\s]+)/$1`$2`/;
-				push @out, $subline;	
+				push @out, $subline;
 				last unless defined $ddl[0];
 			}
 		}


### PR DESCRIPTION
1. get_databases() contains all logic to dump whole databases. So remove duplicate logic and rename method.

2. Drop database without `IF EXISTS` will raise error if the database not exists.

3. Before Use Database, we need create database if not exists.

4. The external keyword is missing when dump. Add it back.